### PR TITLE
Explicitly close PDO connection.

### DIFF
--- a/src/Services/DatabaseChecker.php
+++ b/src/Services/DatabaseChecker.php
@@ -71,6 +71,9 @@ class DatabaseChecker implements StatusCheckerInterface
         $pdo = $this->createConnection($dsn, $user, $pass, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
 
         $pdo->exec($query);
+
+        // explicitly close PDO connection
+        $pdo = null;
     }
 
     private function resolveDsn(array $config): string


### PR DESCRIPTION
It was reported that sometimes PDO connections remains open.

https://www.php.net/manual/en/pdo.connections.php
> To close the connection, you need to destroy the object by ensuring that all remaining references to it are deleted—you do this by assigning **null** to the variable that holds the object. If you don't do this explicitly, PHP will automatically close the connection when your script ends.