### PR TITLE
Fix database checker PDO execute statement

### DIFF
--- a/src/Services/DatabaseChecker.php
+++ b/src/Services/DatabaseChecker.php
@@ -70,7 +70,8 @@ class DatabaseChecker implements StatusCheckerInterface
 
         $pdo = $this->createConnection($dsn, $user, $pass, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
 
-        $pdo->exec($query);
+        $statement = $pdo->prepare($query);
+        $statement->execute();
 
         // explicitly close PDO connection
         $pdo = null;


### PR DESCRIPTION
PDO exec function is not supported for queries that return results.

https://www.php.net/manual/en/pdo.exec.php#61702

It does not cause an error, but notes in MySQL log file
```
[Note] Aborted connection 3 to db: 'my_database' user: 'root' host: 'localhost' (Got an error reading communication packets)
```

You can check that aborted clients count is always increasing 
```
SHOW STATUS LIKE '%Aborted_clients%';
```