### PR TITLE
Fix return type on Command.

### DIFF
--- a/src/Commands/StatusCheckCommand.php
+++ b/src/Commands/StatusCheckCommand.php
@@ -31,7 +31,7 @@ class StatusCheckCommand extends Command
         $this->setDescription('Perform a status check of connections to database, rabbit-mq, other hosts etc');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $details = $this->statusCheckerService->getDetails();
 


### PR DESCRIPTION
In our testing env we are getting a notice **warning** for missing the return type.