### PR TITLE
add check if redis commands work

### DIFF
--- a/src/Services/RedisChecker.php
+++ b/src/Services/RedisChecker.php
@@ -49,6 +49,7 @@ class RedisChecker implements StatusCheckerInterface
         try {
             $cacheClient = new Client($parameters, $options);
             $cacheClient->connect();
+            $cacheClient->randomkey();
         } catch (Exception $exception) {
             return StatusCheckerInterface::STATUS_FAIL;
         }


### PR DESCRIPTION
Currently, `RedisChecker` only checks if we can connect to redis, but it does not check if we can send commands to redis. We had issue where status is OK, but sending command to redis fails. Added check if sending command works as well.