### PR TITLE
Configure explicit versions for phpunit action and fix deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
               with:
                   bootstrap: vendor/autoload.php
                   configuration: phpunit.xml.dist
+                  version: 9.5
+                  php_version: 7.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
                   bootstrap: vendor/autoload.php
                   configuration: phpunit.xml.dist
                   version: 9.5
-                  php_version: 7.4.0
+                  php_version: 8.2.0

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "library",
   "require": {
-    "symfony/console": "^2.0",
+    "symfony/console": ">=2.0",
     "psr/http-message": "^1.0",
     "php": "^7.4 || ^8.0",
     "ext-json": "*"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "library",
   "require": {
-    "symfony/console": ">=2.0",
+    "symfony/console": "^2.0",
     "psr/http-message": "^1.0",
     "php": "^7.4 || ^8.0",
     "ext-json": "*"

--- a/src/Services/DatabaseChecker.php
+++ b/src/Services/DatabaseChecker.php
@@ -155,7 +155,7 @@ class DatabaseChecker implements StatusCheckerInterface
             'driver' => $details['scheme'],
             'user' => $details['user'] ?? '',
             'password' => $details['pass'] ?? '',
-            'database' => substr($details['path'] ?? null, $additionalPathChars),
+            'database' => substr($details['path'] ?? '', $additionalPathChars),
             'host' => $details['host'] ?? '',
         ];
 


### PR DESCRIPTION
Phpunit action was failing due to php and phpunit version incompability. Configured specific versions instead of using latest. Due to `"symfony/console": ">=2.0"` requirement `8.2` php was required for tests, which needed fixing of deprecation for it to pass.